### PR TITLE
support global zones for presets and instruments

### DIFF
--- a/docs/todo.md
+++ b/docs/todo.md
@@ -5,7 +5,7 @@ These are things that will likely be implemented in the future.
 * Comply to the full [SoundFont 2.04 specification](http://www.synthfont.com/sfspec24.pdf).
   * Add support for 24-bit data samples.
   * Better checks if a SoundFont is valid.
-  * Support for global preset and instrument zones.
+  * ~~Support for global preset and instrument zones.~~
 * Maybe add support for sfArk compressed SoundFont files.
 * Add option to create, edit and save SoundFonts.
 * Increase unit test coverage.

--- a/src/chunks/generators.ts
+++ b/src/chunks/generators.ts
@@ -88,7 +88,7 @@ export const getGenerators = (chunk: SF2Chunk, type: 'pgen' | 'igen'): Generator
 
     return {
       id,
-      amount: iterator.getInt16BE()
+      value: iterator.getInt16BE()
     };
   });
 };

--- a/src/soundFont2.ts
+++ b/src/soundFont2.ts
@@ -115,39 +115,37 @@ export class SoundFont2 {
     memoizedPresetNumber: number = 0
   ): Key | null {
     // Get a memoized version of the function
-    return memoize(
-      (keyNumber: number, bankNumber: number, presetNumber: number): Key | null => {
-        const bank = this.banks[bankNumber];
-        if (bank) {
-          const preset = bank.presets[presetNumber];
-          if (preset) {
-            const presetZone = preset.zones.find(zone => this.isKeyInRange(zone, keyNumber));
-            if (presetZone) {
-              const instrument = presetZone.instrument;
-              const instrumentZone = instrument.zones.find(zone =>
-                this.isKeyInRange(zone, keyNumber)
-              );
-              if (instrumentZone) {
-                const sample = instrumentZone.sample;
-                const generators = { ...presetZone.generators, ...instrumentZone.generators };
-                const modulators = { ...presetZone.modulators, ...instrumentZone.modulators };
+    return memoize((keyNumber: number, bankNumber: number, presetNumber: number): Key | null => {
+      const bank = this.banks[bankNumber];
+      if (bank) {
+        const preset = bank.presets[presetNumber];
+        if (preset) {
+          const presetZone = preset.zones.find(zone => this.isKeyInRange(zone, keyNumber));
+          if (presetZone) {
+            const instrument = presetZone.instrument;
+            const instrumentZone = instrument.zones.find(zone =>
+              this.isKeyInRange(zone, keyNumber)
+            );
+            if (instrumentZone) {
+              const sample = instrumentZone.sample;
+              const generators = { ...presetZone.generators, ...instrumentZone.generators };
+              const modulators = { ...presetZone.modulators, ...instrumentZone.modulators };
 
-                return {
-                  keyNumber,
-                  preset,
-                  instrument,
-                  sample,
-                  generators,
-                  modulators
-                };
-              }
+              return {
+                keyNumber,
+                preset,
+                instrument,
+                sample,
+                generators,
+                modulators
+              };
             }
           }
         }
-
-        return null;
       }
-    )(memoizedKeyNumber, memoizedBankNumber, memoizedPresetNumber);
+
+      return null;
+    })(memoizedKeyNumber, memoizedBankNumber, memoizedPresetNumber);
   }
 
   /**
@@ -201,6 +199,7 @@ export class SoundFont2 {
       .map(preset => {
         return {
           header: preset.header,
+          globalZone: preset.globalZone,
           zones: preset.zones.map(zone => {
             return {
               keyRange: zone.keyRange,
@@ -238,6 +237,7 @@ export class SoundFont2 {
       .map(instrument => {
         return {
           header: instrument.header,
+          globalZone: instrument.globalZone,
           zones: instrument.zones.map(zone => {
             return {
               keyRange: zone.keyRange,

--- a/webpack.config.ts
+++ b/webpack.config.ts
@@ -66,12 +66,7 @@ const node: Configuration = merge.smart(config, {
   output: {
     libraryTarget: 'commonjs2',
     filename: '[name].node.js'
-  },
-  plugins: [
-    new webpack.ProvidePlugin({
-      TextDecoder: ['util', 'TextDecoder']
-    })
-  ]
+  }
 });
 
 export default [browser, node];


### PR DESCRIPTION
Hey! I just added support for global zones!
As written in the comment, the first zone of an instrument or preset is interpreted as the global zone, if it does not have a reference (no sampleID for instrument, no instrument for preset).

Quoting the [spec](http://www.synthfont.com/sfspec24.pdf):

```
Spec 7.3: If a preset has more than one zone, the first zone may be a global zone. A global zone is determined by the fact that the last generator in the list is not an Instrument generator.
Spec 7.9: "Unless the zone is a global zone, the last generator in the list is a “sampleID” generator"
```

If a global zone exists, it will now be added to the preset / instrument object as `globalZone` property, so it won't break anything. If you're happy with the changes, I would be really happy if you could build and publish the package, so I can use it in my project :) thank you for creating this lib !